### PR TITLE
fix no difference being reported for src only or dst only files

### DIFF
--- a/cmd/p4harmonize/update.go
+++ b/cmd/p4harmonize/update.go
@@ -319,10 +319,12 @@ func Reconcile(src []p4.DepotFile, dst []p4.DepotFile) DepotFileDiff {
 
 	for i := is; i < len(src); i++ {
 		out.SrcOnly = append(out.SrcOnly, src[i])
+		out.HasDifference = true
 	}
 
 	for i := id; i < len(dst); i++ {
 		out.DstOnly = append(out.DstOnly, dst[i])
+		out.HasDifference = true
 	}
 
 	return out


### PR DESCRIPTION
First off just wanted to say a big thanks for putting this together! I'd been using some half built scripts to do this operation before, and this tool will save a lot of time going forward.

I ran the tool to integrate into a brand new depot (started a //UE5), but it reported no changes. This fix makes sure that Reconcile sets `hasDifference` to true in the event that there are only src only or dst only files.