### PR TITLE
fix depot prefix not being trimmed when cases differ

### DIFF
--- a/internal/p4/p4.go
+++ b/internal/p4/p4.go
@@ -193,7 +193,8 @@ func (p *P4) runAndParseDepotFiles(cmd string) ([]DepotFile, error) {
 						return fmt.Errorf("error parsing depot prefix: %w", err)
 					}
 				}
-				cur.Path = strings.TrimPrefix(raw, prefix)
+				// remove the prefix by length since the depot prefix may differ in case
+				cur.Path = raw[len(prefix):]
 			case strings.HasPrefix(line[4:], "action"):
 				cur.Action = strings.TrimSpace(line[10:])
 			case strings.HasPrefix(line[4:], "change"):


### PR DESCRIPTION
I ran into an usual case when integrating Release-5.0-EarlyAccess-Minimal into a fresh depot, this file failed to copy, due to it's depot prefix not being removed:

`//Ue5/Release-5.0-EarlyAccess/Engine/Plugins/Runtime/Metasound/Source/MetasoundFrontend/Public/MetasoundEnum.h`

Notice that the prefix case is different `//Ue5` instead of `//UE5` that all other files have.

Because the depot prefix is cached after the first file, the prefix was not being removed due to having a different case, and file copy operations failed due to the full depot path being used. This fix removes prefixes by length which should handle any case differences.