### PR TITLE
optimize adding src only files by batching the p4 add command

### DIFF
--- a/cmd/p4harmonize/update.go
+++ b/cmd/p4harmonize/update.go
@@ -146,22 +146,31 @@ func Harmonize(log Logger, cfg Config) error {
 	}
 
 	// For each file that only exists in the source, copy it over then add it to the destination.
-	for _, src := range diff.SrcOnly {
-		srcPath := filepath.Join(str.ClientRoot, src.Path)
-		dstPath := filepath.Join(dstClientRoot, src.Path)
+	srcOnlyFilesByType := GroupFilesByType(diff.SrcOnly)
 
-		// copy file from source root to destination root
-		if err := PerforceFileCopy(srcPath, dstPath, src.Type); err != nil {
-			return err
+	for srcType, srcFiles := range srcOnlyFilesByType {
+		var pathsToAdd []string
+
+		for _, src := range srcFiles {
+			srcPath := filepath.Join(str.ClientRoot, src.Path)
+			dstPath := filepath.Join(dstClientRoot, src.Path)
+
+			// copy file from source root to destination root
+			if err := PerforceFileCopy(srcPath, dstPath, src.Type); err != nil {
+				return err
+			}
+
+			// add to the depot
+			dstPathForAdd, err := p4.UnescapePath(dstPath)
+			if err != nil {
+				return fmt.Errorf("Error unescaping '%s': %w", dstPath, err)
+			}
+
+			pathsToAdd = append(pathsToAdd, dstPathForAdd)
 		}
 
-		// add to the depot
-		dstPathForAdd, err := p4.UnescapePath(dstPath)
-		if err != nil {
-			return fmt.Errorf("Error unescaping '%s': %w", dstPath, err)
-		}
-		if err := p4dst.Add(dstPathForAdd, p4.Changelist(cl), p4.Type(src.Type)); err != nil {
-			return fmt.Errorf("Unable to open '%s' for add: %w", dstPath, err)
+		if err := p4dst.Add(pathsToAdd, p4.Changelist(cl), p4.Type(srcType)); err != nil {
+			return fmt.Errorf("Unable to open %d file(s) for add: %w", len(pathsToAdd), err)
 		}
 	}
 
@@ -387,4 +396,16 @@ func verifyAndCopy(srcPath, dstPath string) error {
 		return fmt.Errorf("Expected '%s' to copy %d bytes to '%s', but only %d were copied", srcPath, n, dstPath, srcSize)
 	}
 	return nil
+}
+
+// Splits a list of files into groups of files in which each group
+// shares the same perforce file type
+func GroupFilesByType(files []p4.DepotFile) map[string][]p4.DepotFile {
+	filesByType := map[string][]p4.DepotFile{}
+
+	for _, file := range files {
+		filesByType[file.Type] = append(filesByType[file.Type], file)
+	}
+
+	return filesByType
 }

--- a/internal/p4/add.go
+++ b/internal/p4/add.go
@@ -26,9 +26,10 @@ func (p *P4) Add(paths []string, opts ...Option) error {
 	}
 
 	// write paths to disk to avoid command line character limit
-	file, err := os.CreateTemp("", "p4harmonize_add_*.txt")
+	tmpFilePattern := "p4harmonize_add_*.txt"
+	file, err := os.CreateTemp("", tmpFilePattern)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating temp file for pattern %s: %w", tmpFilePattern, err)
 	}
 	defer os.Remove(file.Name())
 	file.WriteString(strings.Join(paths, "\n"))


### PR DESCRIPTION
This optimization combines multiple `p4 add` commands of the same file type into a single command by first grouping files to be added by perforce file type, then writing the paths to a temporary file (to avoid command line argument length limits), and reading them from disk using the perforce `-x <argfile>` global option.

Integrating unreal engine into a fresh depot was resulting in around 200k `p4 add` commands, and our perforce server connection isn't all that great to start with. I didn't actually test to see how long the operation was before, but based on the logs it was performing about 1-2 adds per second, which would have been many hours.

After batching the adds, the result is I think around ~20 or so `p4 add` commands (one per perforce file type). If you exclude the initial sync time from epic's perforce (which I had done before using the tool), the total time to run p4harmonize on a new UE5 depot was 17m 36s, most of which is from file copy operations.

A similar optimization could likely be made for Delete.

Please note that I've also added the `-I` flag to disable p4 ignore files during add, since in this case we want to make sure files get added exactly matching the src depot, regardless of whether they are ignored, e.g. by Epic's `p4ignore.txt`. I considered making this a separate PR, but wanted to make it easier to merge and the two would have conflicted.
