### PR TITLE
Optimize p4 delete and edit commands by batching them

### DIFF
--- a/cmd/p4harmonize/update.go
+++ b/cmd/p4harmonize/update.go
@@ -124,26 +124,38 @@ func Harmonize(log Logger, cfg Config) error {
 
 	// For each file with the capitalization or the types different, copy the file, then make
 	// sure perforce is set to fix the mismatch(es).
-	for _, pair := range diff.Match {
-		srcPath := filepath.Join(str.ClientRoot, pair[0].Path)
-		dstPathOld := filepath.Join(dstClientRoot, pair[1].Path)
-		dstPathNew := filepath.Join(dstClientRoot, pair[0].Path)
+	matchFilePairsByType := GroupFilePairsByType(diff.Match)
 
-		// copy file from source root to destination root
-		if err := PerforceFileCopy(srcPath, dstPathOld, pair[0].Type); err != nil {
-			return err
-		}
+	for newType, diffFiles := range matchFilePairsByType {
+		var pathsToEdit []string
 
-		// mark file in destination for edit with type
-		if err := p4dst.Edit(dstPathOld, p4.Changelist(cl), p4.Type(pair[0].Type)); err != nil {
-			return fmt.Errorf("Unable to open '%s' for edit: %w", dstPathOld, err)
-		}
+		for _, pair := range diffFiles {
+			srcPath := filepath.Join(str.ClientRoot, pair[0].Path)
+			dstPathNew := filepath.Join(dstClientRoot, pair[0].Path)
+			dstPathOld := filepath.Join(dstClientRoot, pair[1].Path)
 
-		if dstPathOld != dstPathNew {
-			// mark file in destination for move
-			if err := p4dst.Move(dstPathOld, dstPathNew, p4.Changelist(cl), p4.Type(pair[0].Type)); err != nil {
-				return fmt.Errorf("Unable to open '%s' for move to '%s': %w", dstPathOld, dstPathNew, err)
+			// copy file from source root to destination root
+			if err := PerforceFileCopy(srcPath, dstPathOld, pair[0].Type); err != nil {
+				return err
 			}
+
+			if dstPathOld != dstPathNew {
+				// path has changed, do a single file edit and move
+				if err := p4dst.Edit([]string{dstPathOld}, p4.Changelist(cl), p4.Type(newType)); err != nil {
+					return fmt.Errorf("Unable to open '%s' for edit: %w", dstPathOld, err)
+				}
+				if err := p4dst.Move(dstPathOld, dstPathNew, p4.Changelist(cl), p4.Type(newType)); err != nil {
+					return fmt.Errorf("Unable to open '%s' for move to '%s': %w", dstPathOld, dstPathNew, err)
+				}
+			} else {
+				// add to array for batch edit
+				pathsToEdit = append(pathsToEdit, dstPathOld)
+			}
+		}
+
+		// mark files in destination for edit with type
+		if err := p4dst.Edit(pathsToEdit, p4.Changelist(cl), p4.Type(newType)); err != nil {
+			return fmt.Errorf("Unable to open %d file(s) for edit: %w", len(pathsToEdit), err)
 		}
 	}
 
@@ -412,4 +424,16 @@ func GroupFilesByType(files []p4.DepotFile) map[string][]p4.DepotFile {
 	}
 
 	return filesByType
+}
+
+// Splits a list of file pairs (new, old) into groups in which each group
+// shares the same perforce file type (for the new file)
+func GroupFilePairsByType(filePairs [][2]p4.DepotFile) map[string][][2]p4.DepotFile {
+	filePairsByType := map[string][][2]p4.DepotFile{}
+
+	for _, filePair := range filePairs {
+		filePairsByType[filePair[0].Type] = append(filePairsByType[filePair[0].Type], filePair)
+	}
+
+	return filePairsByType
 }

--- a/cmd/p4harmonize/update.go
+++ b/cmd/p4harmonize/update.go
@@ -113,11 +113,13 @@ func Harmonize(log Logger, cfg Config) error {
 	// For each file that only exists in the destination, mark it for delete in the destination.
 	// NOTE: Process DstOnly BEFORE processing Match, so that any AppleDouble "%" files that
 	// got checked directly into the destination are cleaned up properly.
+	var pathsToDelete []string
 	for _, dst := range diff.DstOnly {
 		dstPath := filepath.Join(dstClientRoot, dst.Path)
-		if err := p4dst.Delete(dstPath, p4.Changelist(cl)); err != nil {
-			return fmt.Errorf("Unable to mark '%s' for delete: %w", dstPath, err)
-		}
+		pathsToDelete = append(pathsToDelete, dstPath)
+	}
+	if err := p4dst.Delete(pathsToDelete, p4.Changelist(cl)); err != nil {
+		return fmt.Errorf("Unable to mark %d file(s) for delete: %w", len(pathsToDelete), err)
 	}
 
 	// For each file with the capitalization or the types different, copy the file, then make

--- a/internal/p4/delete.go
+++ b/internal/p4/delete.go
@@ -2,11 +2,12 @@ package p4
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
 
 // Delete marks a file in the depot for delete (which deletes any local copy of the file as well).
-func (p *P4) Delete(path string, opts ...Option) error {
+func (p *P4) Delete(paths []string, opts ...Option) error {
 	var args []string
 	for _, o := range opts {
 		switch ot := o.(type) {
@@ -18,5 +19,15 @@ func (p *P4) Delete(path string, opts ...Option) error {
 			return fmt.Errorf("unrecognized option %s", o.String())
 		}
 	}
-	return p.sh.Cmdf(`%s delete %s "%s"`, p.cmd(), strings.Join(args, " "), path).RunErr()
+
+	// write paths to disk to avoid command line character limit
+	tmpFilePattern := "p4harmonize_delete_*.txt"
+	file, err := os.CreateTemp("", tmpFilePattern)
+	if err != nil {
+		return fmt.Errorf("Error creating temp file for pattern %s: %w", tmpFilePattern, err)
+	}
+	defer os.Remove(file.Name())
+	file.WriteString(strings.Join(paths, "\n"))
+
+	return p.sh.Cmdf(`%s -x "%s" delete %s`, p.cmd(), file.Name(), strings.Join(args, " ")).RunErr()
 }


### PR DESCRIPTION
Very similar to the last optimization patch that batched the add commands. Hadn't gotten around to doing this until the new version of UE5 came out. I haven't written any test cases, but wanted to submit this now anyway since I've used it successfully to go from UE5EA -> UE5 release.