### PR TITLE
Accelerate reconcile using Perforce digests 

### DIFF
--- a/internal/p4/files.go
+++ b/internal/p4/files.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 )
 
-// ListDepotFiles runs "p4 files -e" and parses the results into a slice of DepotFile structs.
+// ListDepotFiles runs "p4 fstat" and parses the results into a slice of DepotFile structs.
 // Order of resulting slice is alphabetical by Path, ignoring case.
 func (p *P4) ListDepotFiles() ([]DepotFile, error) {
-	return p.runAndParseDepotFiles(fmt.Sprintf(`%s -z tag files -e //%s/...`, p.cmd(), p.Client))
+	return p.runAndParseDepotFiles(fmt.Sprintf(`%s fstat -T depotFile,headAction,headChange,headType,digest -Ol -F '^(headAction=move/delete | headAction=purge | headAction=archive | headAction=delete)' //%s/...`, p.cmd(), p.Client))
 }


### PR DESCRIPTION
Instead of copying every file from the source repo to the destination
repo and then running `p4 revert -a`, switch to comparing the
Perforce-provided digest and only copying the files whose digest, type,
or case has changed.

1. Replaces `p4 -ztag files -e` with
   `p4 fstat -T depotFile,headAction,headChange,headType,digest -Ol -F '^(headAction=move/delete | headAction=purge | headAction=archive | headAction=delete)'`
    (which contains the same information, though it also includes the digest)

2. Updates `p4.runAndParseDepotFiles` to support the `head*` names
   of fields and also parse `digest`

3. Modifies `Reconcile` to compare digests and only adding files to
   `Match` if they're actually different in some way

This also has the benefit of not returning that there are no changes if
only existing file contents has changed, not paths or types.