### PR TITLE
Update minimum required go

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-2019]
-        go-ver: ["1.20"]
+        go-ver: ["1.19"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ When it is done, there will be a changelist that must be submitted by hand, givi
 ## Development setup
 
 - Ensure you have all the [Runtime requirements](#runtime-requirements)
-- Ensure you have a [recent version of Go (1.17+)](https://go.dev/dl/)
+- Ensure you have a [recent version of Go (1.19+)](https://go.dev/dl/)
   - Ensure that $GOPATH/bin is added to your $PATH environment variable.
 - To run all the tests, you'll want to have Docker installed
   - On Windows and Mac, you'll want [Docker Desktop](https://www.docker.com/products/docker-desktop)

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
 `p4harmonize` was built with Unreal Engine source in mind, where the Epic licensee perforce server is used as the source, and a dedicated stream on a project's perforce server is used as the destination. It is intended to be used with a setup similar to [the one recommended by Epic](https://docs.unrealengine.com/4.26/en-US/ProgrammingAndScripting/ProgrammingWithCPP/DownloadingSourceCode/UpdatingSourceCode/#integrating,merging,andbranching). For example, a recent Unreal project I worked on had the following setup:
 
-name | description
---- | ---
-`//proj/engine_epic` | exact copy of a specific UE version from Epic's perforce server (p4harmonize targets this stream, no project-specific changes should ever end up here)
-`//proj/engine_merge` | dedicated space for a human to merge main with new engine drops; ideally QA will sign off on a build from this branch before the merged engine changes are brought to main
-`//proj/main` | our mainline; lots of people work here, so a broken build can be very costly
+| name                  | description                                                                                                                                                                |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `//proj/engine_epic`  | exact copy of a specific UE version from Epic's perforce server (p4harmonize targets this stream, no project-specific changes should ever end up here)                     |
+| `//proj/engine_merge` | dedicated space for a human to merge main with new engine drops; ideally QA will sign off on a build from this branch before the merged engine changes are brought to main |
+| `//proj/main`         | our mainline; lots of people work here, so a broken build can be very costly                                                                                               |
 
 ![The output of v0.5.0 when there are no changes](images/0.5.0-no-changes.png)
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,10 +1,21 @@
 #!/bin/bash -e
+required_minor_version=19
+
 cd $(dirname "$0")
 
-echo "Checking for go..."
+echo "Checking for go v1.$required_minor_version..."
 if ! command -v go &> /dev/null
 then
   echo "Could not find go. Make sure it is installed and in your path."
+  echo "https://golang.org/dl/"
+  exit 1
+fi
+
+go_version=$(go version | awk '{print $3}' | sed 's/^go//')
+major_version=$(echo "$go_version" | cut -f1 -d.)
+minor_version=$(echo "$go_version" | cut -f2 -d.)
+if [[ "$major_version" -lt 1 || ( "$major_version" -eq 1 && "$minor_version" -lt "$required_minor_version" ) ]]; then
+  echo "Need go version 1.$required_minor_version, you have $go_version. Please upgrade."
   echo "https://golang.org/dl/"
   exit 1
 fi
@@ -16,4 +27,4 @@ then
   ./reinstall-mage.sh
 fi
 
-echo "All dependancies are installed."
+echo "All dependencies are installed."


### PR DESCRIPTION
`encoding.binary.BigEndian.AppendUint32` was only added in 1.19, so bump the required version to that.
